### PR TITLE
Convert to Maven project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Maven
+target/
+out/
+
+# IntelliJ
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.agnacore.spaceship</groupId>
+  <artifactId>spaceship</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>spaceship</name>
+  <!-- FIXME change it to the project's website -->
+  <url>http://www.example.com</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+      <plugins>
+        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <plugin>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.0.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <plugin>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-project-info-reports-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,38 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-controls</artifactId>
+      <version>20</version>
+    </dependency>
   </dependencies>
 
   <build>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
       <plugins>
+        <plugin>
+          <groupId>org.openjfx</groupId>
+          <artifactId>javafx-maven-plugin</artifactId>
+          <version>0.0.8</version>
+          <executions>
+            <execution>
+              <id>default-cli</id>
+              <configuration>
+                <mainClass>com.agnacore.spaceship.main.Spaceship</mainClass>
+              </configuration>
+            </execution>
+            <execution>
+              <id>debug</id>
+              <configuration>
+                <options>
+                  <option>-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=127.0.0.1:8001</option>
+                </options>
+                <mainClass>com.agnacore.spaceship.main.Spaceship</mainClass>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>

--- a/src/application/Graphics.java
+++ b/src/application/Graphics.java
@@ -1,5 +1,0 @@
-package application;
-
-public class Graphics {
-
-}

--- a/src/main/java/com/agnacore/spaceship/application/Graphics.java
+++ b/src/main/java/com/agnacore/spaceship/application/Graphics.java
@@ -1,0 +1,5 @@
+package com.agnacore.spaceship.application;
+
+public class Graphics {
+
+}

--- a/src/main/java/com/agnacore/spaceship/game/Bullet.java
+++ b/src/main/java/com/agnacore/spaceship/game/Bullet.java
@@ -1,4 +1,4 @@
-package game;
+package com.agnacore.spaceship.game;
 
 public class Bullet extends Projectile {
 	// boolet.

--- a/src/main/java/com/agnacore/spaceship/game/Enemy.java
+++ b/src/main/java/com/agnacore/spaceship/game/Enemy.java
@@ -1,4 +1,4 @@
-package game;
+package com.agnacore.spaceship.game;
 
 public class Enemy extends Ship {
 	// unique enemy stuff like moving and shooting logic

--- a/src/main/java/com/agnacore/spaceship/game/Game.java
+++ b/src/main/java/com/agnacore/spaceship/game/Game.java
@@ -1,4 +1,4 @@
-package game;
+package com.agnacore.spaceship.game;
 
 public class Game {
 	// store variables like lives, score, etc.

--- a/src/main/java/com/agnacore/spaceship/game/Missile.java
+++ b/src/main/java/com/agnacore/spaceship/game/Missile.java
@@ -1,4 +1,4 @@
-package game;
+package com.agnacore.spaceship.game;
 
 public class Missile extends Projectile {
 	// the big one

--- a/src/main/java/com/agnacore/spaceship/game/Player.java
+++ b/src/main/java/com/agnacore/spaceship/game/Player.java
@@ -1,4 +1,4 @@
-package game;
+package com.agnacore.spaceship.game;
 
 public class Player extends Ship {
 	// unique player stuff like moving and input

--- a/src/main/java/com/agnacore/spaceship/game/Projectile.java
+++ b/src/main/java/com/agnacore/spaceship/game/Projectile.java
@@ -1,4 +1,4 @@
-package game;
+package com.agnacore.spaceship.game;
 
 public class Projectile {
 	// superclass baybee

--- a/src/main/java/com/agnacore/spaceship/game/Ship.java
+++ b/src/main/java/com/agnacore/spaceship/game/Ship.java
@@ -1,4 +1,4 @@
-package game;
+package com.agnacore.spaceship.game;
 
 public class Ship {
 	// superclass baybee

--- a/src/main/java/com/agnacore/spaceship/main/Spaceship.java
+++ b/src/main/java/com/agnacore/spaceship/main/Spaceship.java
@@ -1,10 +1,23 @@
 package com.agnacore.spaceship.main;
 
-public class Spaceship {
+import javafx.application.Application;
+import javafx.scene.control.Alert;
+import javafx.stage.Stage;
 
-	public static void main(String[] args) {
+
+public class Spaceship extends Application {
+
+	public static void main(String[] args)
+	{
+		launch();
+	}
+
+	@Override
+	public void start(Stage primaryStage) throws Exception {
 		// start the game
-		System.out.println("Hello, world!");
+		Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+		alert.setContentText("Hello, world!");
+		alert.showAndWait();
 	}
 
 }

--- a/src/main/java/com/agnacore/spaceship/main/Spaceship.java
+++ b/src/main/java/com/agnacore/spaceship/main/Spaceship.java
@@ -1,10 +1,10 @@
-package main;
+package com.agnacore.spaceship.main;
 
 public class Spaceship {
 
 	public static void main(String[] args) {
 		// start the game
-
+		System.out.println("Hello, world!");
 	}
 
 }

--- a/src/test/java/com/agnacore/spaceship/AppTest.java
+++ b/src/test/java/com/agnacore/spaceship/AppTest.java
@@ -1,0 +1,20 @@
+package com.agnacore.spaceship;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest 
+{
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue()
+    {
+        assertTrue( true );
+    }
+}


### PR DESCRIPTION
## Changes in this PR

This updates the project to use Maven in order to better manage project dependencies. The package structure is changed somewhat but should maintain the general arrangement of the existing source files.

JavaFX is a known project dependency, so we pull that from Maven while we're at it.

Also changes the targeted Java version to 17. It's currently the latest version with long-term support.

## How to run

`mvn clean javafx:run`